### PR TITLE
chore: bump windows crate to v.0.59.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ keywords = ["shared-memory", "desktop-duplication", "windows"]
 
 
 [dependencies]
-windows = { version = "0.48.0", features = ["Win32_Graphics_Dxgi", "Win32_Graphics_Direct3D11", "Win32_Foundation", "Win32_Graphics_Direct3D", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_System_Memory", "Win32_Security"] }
+windows = { version = "0.59.0", features = ["Win32_Graphics_Dxgi", "Win32_Graphics_Direct3D11", "Win32_Foundation", "Win32_Graphics_Direct3D", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_System_Memory", "Win32_Security"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-duplication"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT"
 authors = ["DiscreteTom <discrete_tom@outlook.com>"]

--- a/src/capturer/custom.rs
+++ b/src/capturer/custom.rs
@@ -119,6 +119,7 @@ impl Capturer for CustomCapturer<'_> {
   }
 }
 
+#[allow(elided_named_lifetimes)]
 impl DuplicationContext {
   pub fn custom_capturer<'a>(&'a self, buffer: &'a mut [u8]) -> Result<CustomCapturer> {
     CustomCapturer::<'a>::new(self, buffer)

--- a/src/capturer/shared.rs
+++ b/src/capturer/shared.rs
@@ -98,7 +98,7 @@ impl<'a> SharedCapturer<'a> {
       );
 
       if buffer_ptr.Value.is_null() {
-        CloseHandle(file);
+        let _ = CloseHandle(file);
         return Err(Error::new("MapViewOfFile returned null"));
       }
       let buffer = buffer_ptr.Value as *mut u8;
@@ -137,7 +137,7 @@ impl<'a> SharedCapturer<'a> {
       );
 
       if buffer_ptr.Value.is_null() {
-        CloseHandle(file);
+        let _ = CloseHandle(file);
         return Err(Error::new("MapViewOfFile returned null"));
       }
       let buffer = buffer_ptr.Value as *mut u8;

--- a/src/duplication_context.rs
+++ b/src/duplication_context.rs
@@ -4,7 +4,7 @@ use std::ptr;
 use windows::Win32::Graphics::Dxgi::DXGI_OUTDUPL_DESC;
 use windows::Win32::Graphics::Gdi::{GetMonitorInfoW, MONITORINFO};
 use windows::{
-  core::ComInterface,
+  core::Interface,
   Win32::Graphics::{
     Direct3D11::{
       ID3D11Device, ID3D11DeviceContext, ID3D11Texture2D, D3D11_BIND_FLAG, D3D11_CPU_ACCESS_READ,
@@ -58,17 +58,14 @@ impl DuplicationContext {
 
   /// This is usually used to get the screen's position and size.
   pub fn dxgi_output_desc(&self) -> Result<DXGI_OUTPUT_DESC> {
-    let mut desc = DXGI_OUTPUT_DESC::default();
-    unsafe { self.output.GetDesc(&mut desc) }
+    let ret = unsafe { self.output.GetDesc() }
       .map_err(|e| Error::windows("DXGI_OUTPUT_DESC.GetDesc", e))?;
-    Ok(desc)
+    Ok(ret)
   }
 
   /// This is usually used to get the screen's pixel width/height and buffer size.
   pub fn dxgi_outdupl_desc(&self) -> DXGI_OUTDUPL_DESC {
-    let mut desc = DXGI_OUTDUPL_DESC::default();
-    unsafe { self.output_duplication.GetDesc(&mut desc) };
-    desc
+    unsafe { self.output_duplication.GetDesc() }
   }
 
   pub fn create_readable_texture(
@@ -79,9 +76,9 @@ impl DuplicationContext {
 
     // create a readable texture description
     let texture_desc = D3D11_TEXTURE2D_DESC {
-      BindFlags: D3D11_BIND_FLAG::default(),
-      CPUAccessFlags: D3D11_CPU_ACCESS_READ,
-      MiscFlags: D3D11_RESOURCE_MISC_FLAG::default(),
+      BindFlags: D3D11_BIND_FLAG::default().0 as u32,
+      CPUAccessFlags: D3D11_CPU_ACCESS_READ.0 as u32,
+      MiscFlags: D3D11_RESOURCE_MISC_FLAG::default().0 as u32,
       Usage: D3D11_USAGE_STAGING, // A resource that supports data transfer (copy) from the GPU to the CPU.
       Width: if output_desc.Rotation.0 == 2 || output_desc.Rotation.0 == 4 {
         dupl_desc.ModeDesc.Height

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,7 +1,8 @@
 use crate::duplication_context::DuplicationContext;
 use crate::error::Error;
 use crate::model::Result;
-use windows::core::ComInterface;
+use windows::core::Interface;
+use windows::Win32::Foundation::HMODULE;
 use windows::Win32::Graphics::Direct3D::{D3D_DRIVER_TYPE_UNKNOWN, D3D_FEATURE_LEVEL_9_1};
 use windows::Win32::Graphics::Direct3D11::{
   D3D11CreateDevice, ID3D11Device, ID3D11DeviceContext, D3D11_CREATE_DEVICE_FLAG, D3D11_SDK_VERSION,
@@ -71,7 +72,7 @@ impl Manager {
         D3D11CreateDevice(
           &adapter,
           D3D_DRIVER_TYPE_UNKNOWN,
-          None,
+          HMODULE(std::ptr::null_mut()),
           D3D11_CREATE_DEVICE_FLAG(0),
           None,
           D3D11_SDK_VERSION,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -63,7 +63,7 @@ impl Manager {
 
     // prepare device and output
     for (adapter, outputs) in adapter_outputs {
-      let mut device: Option<ID3D11Device> = None.clone();
+      let mut device: Option<ID3D11Device> = None;
       let mut device_context: Option<ID3D11DeviceContext> = None.clone();
       let mut feature_level = D3D_FEATURE_LEVEL_9_1;
 
@@ -82,7 +82,10 @@ impl Manager {
         )
       }
       .map_err(|e| Error::windows("D3D11CreateDevice", e))?;
-      let device = device.unwrap();
+      let device = match device {
+        Some(dev) => dev,
+        None => continue
+      };
       let device_context = device_context.unwrap();
 
       // create duplication output for each output


### PR DESCRIPTION
I've updated the windows crate and fixed a bunch of regressions and syntax warnings with the latest Rust. 
Please advise.
Thank you